### PR TITLE
Fix condition of comparing QAN filter omit query

### DIFF
--- a/qan/analyzer/mysql/worker/perfschema/worker.go
+++ b/qan/analyzer/mysql/worker/perfschema/worker.go
@@ -275,7 +275,10 @@ SELECT
 
 			var omit bool
 			for _, omitQuery := range filterOmit {
-				if strings.TrimSpace(strings.ToLower(row.DigestText)) == strings.TrimSpace(strings.ToLower(omitQuery)) {
+				if strings.HasPrefix(
+					strings.TrimSpace(strings.ToLower(row.DigestText)),
+					strings.TrimSpace(strings.ToLower(omitQuery)),
+				) {
 					omit = true
 					break
 				}
@@ -397,7 +400,10 @@ SELECT
 
 			var omit bool
 			for _, omitQuery := range filterOmit {
-				if strings.TrimSpace(strings.ToLower(row.SQLText)) == strings.TrimSpace(strings.ToLower(omitQuery)) {
+				if strings.HasPrefix(
+					strings.TrimSpace(strings.ToLower(row.SQLText)),
+					strings.TrimSpace(strings.ToLower(omitQuery)),
+				) {
 					omit = true
 					break
 				}

--- a/qan/analyzer/mysql/worker/rdsslowlog/worker.go
+++ b/qan/analyzer/mysql/worker/rdsslowlog/worker.go
@@ -538,7 +538,10 @@ EVENT_LOOP:
 					// check if query should be omitted first
 					var omit bool
 					for _, omitQuery := range w.config.FilterOmit {
-						if strings.TrimSpace(strings.ToLower(fingerprint)) == strings.TrimSpace(strings.ToLower(omitQuery)) {
+						if strings.HasPrefix(
+							strings.TrimSpace(strings.ToLower(fingerprint)),
+							strings.TrimSpace(strings.ToLower(omitQuery)),
+						) {
 							omit = true
 							break
 						}

--- a/qan/analyzer/mysql/worker/slowlog/worker.go
+++ b/qan/analyzer/mysql/worker/slowlog/worker.go
@@ -344,7 +344,10 @@ EVENT_LOOP:
 			// check if query should be omitted first
 			var omit bool
 			for _, omitQuery := range w.config.FilterOmit {
-				if strings.TrimSpace(strings.ToLower(fingerprint)) == strings.TrimSpace(strings.ToLower(omitQuery)) {
+				if strings.HasPrefix(
+					strings.TrimSpace(strings.ToLower(fingerprint)),
+					strings.TrimSpace(strings.ToLower(omitQuery)),
+				) {
 					omit = true
 					break
 				}


### PR DESCRIPTION
Currently qan-agent compares the omit statements to the fingerprint with **exact match**, this will work for those statements with single command, e.g. `COMMIT`, `ROLLBACK` and so on. But this will not work for those statements that has further arguments, e.g. `SET xxx` and so on, that's why this patch is needed.